### PR TITLE
Add SonarCloud

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 .monitor
 .nyc_output
 .s3creds
+.scannerwork
 .vscode
 .vscode/*
 /reports

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
- # Branch whitelist
+addons:
+  sonarcloud:
+    organization: "skye2k2-github"
+    # SONAR_TOKEN managed via environment variable
+# Branch whitelist
 branches:
   only:
     - master
@@ -41,3 +45,4 @@ after_failure:
 
 after_script:
   - bin/after_script.sh
+  - sonar-scanner

--- a/README.md
+++ b/README.md
@@ -1,6 +1,22 @@
 # Dev CLI
 
-[![Maintainability](https://api.codeclimate.com/v1/badges/84afc823b7f3426f7614/maintainability)](https://codeclimate.com/github/skye2k2/dev-cli/maintainability) [![Test Coverage](https://api.codeclimate.com/v1/badges/84afc823b7f3426f7614/test_coverage)](https://codeclimate.com/github/skye2k2/dev-cli/test_coverage) [![Build Status](https://travis-ci.com/skye2k2/dev-cli.svg?branch=master)](https://travis-ci.com/skye2k2/dev-cli)
+[![Build Status](https://travis-ci.com/skye2k2/dev-cli.svg?branch=master)](https://travis-ci.com/skye2k2/dev-cli)
+
+[![Maintainability](https://api.codeclimate.com/v1/badges/84afc823b7f3426f7614/maintainability)](https://codeclimate.com/github/skye2k2/dev-cli/maintainability) [![Test Coverage](https://api.codeclimate.com/v1/badges/84afc823b7f3426f7614/test_coverage)](https://codeclimate.com/github/skye2k2/dev-cli/test_coverage) 
+
+Available SonarCloud badges:
+
+[![Bugs](https://sonarcloud.io/api/project_badges/measure?project=skye2k2-dev-cli&metric=bugs)](https://sonarcloud.io/dashboard?id=skye2k2-dev-cli)
+[![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=skye2k2-dev-cli&metric=code_smells)](https://sonarcloud.io/dashboard?id=skye2k2-dev-cli)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=skye2k2-dev-cli&metric=coverage)](https://sonarcloud.io/dashboard?id=skye2k2-dev-cli)
+[![Duplicated Lines (%)](https://sonarcloud.io/api/project_badges/measure?project=skye2k2-dev-cli&metric=duplicated_lines_density)](https://sonarcloud.io/dashboard?id=skye2k2-dev-cli)
+[![Lines of Code](https://sonarcloud.io/api/project_badges/measure?project=skye2k2-dev-cli&metric=ncloc)](https://sonarcloud.io/dashboard?id=skye2k2-dev-cli)
+[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=skye2k2-dev-cli&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=skye2k2-dev-cli)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=skye2k2-dev-cli&metric=alert_status)](https://sonarcloud.io/dashboard?id=skye2k2-dev-cli)
+[![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=skye2k2-dev-cli&metric=reliability_rating)](https://sonarcloud.io/dashboard?id=skye2k2-dev-cli)
+[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=skye2k2-dev-cli&metric=security_rating)](https://sonarcloud.io/dashboard?id=skye2k2-dev-cli)
+[![Technical Debt](https://sonarcloud.io/api/project_badges/measure?project=skye2k2-dev-cli&metric=sqale_index)](https://sonarcloud.io/dashboard?id=skye2k2-dev-cli)
+[![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=skye2k2-dev-cli&metric=vulnerabilities)](https://sonarcloud.io/dashboard?id=skye2k2-dev-cli)
 
 ## Intro
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,28 @@
+sonar.host.url=https://sonarcloud.io
+sonar.organization=skye2k2-github
+
+sonar.projectKey=skye2k2-dev-cli
+sonar.projectName=skye2k2-dev-cli
+
+# Provides a tag to reference in the activity panel.
+# sonar.projectVersion=1.0
+
+# Path is relative to the sonar-project.properties file.
+# This property is optional if sonar.modules is set.
+sonar.sources=.
+
+# Comma-delimited list of paths to LCOV coverage report files. Paths may be absolute or relative to project root.
+sonar.javascript.lcov.reportPaths="./reports/coverage/lcov.info"
+sonar.typescript.lcov.reportPaths="./reports/coverage/lcov.info"
+
+# Patterns used to exclude files from coverage report.
+sonar.coverage.exclusions="**/test/*"
+
+# Pattern used to ingore files for duplication detection.
+sonar.cpd.exclusions="**/test/*"
+
+# Encoding of the source code. Default is default system encoding.
+# sonar.sourceEncoding=UTF-8
+
+# IMPORTANT!
+# sonar.login gets read in from the SONAR_TOKEN environment variable.


### PR DESCRIPTION
Add base project configuration (with helpful notes and exclusions).
Add .gitignore exclusions for Sonar-related files.
Add sonarcloud addon to Travis CI configuration.
Add available SonarCloud status badges to README as example.